### PR TITLE
SFTP extends SSH2 __construct()

### DIFF
--- a/lib/Sinner/Phpseclib/Net/SFTP.php
+++ b/lib/Sinner/Phpseclib/Net/SFTP.php
@@ -265,7 +265,7 @@ class Net_SFTP extends Net_SSH2 {
      */
     function __construct($host, $port = 22, $timeout = 10)
     {
-        parent::Net_SSH2($host, $port, $timeout);
+        parent::__construct($host, $port, $timeout);
         $this->packet_types = array(
             1  => 'NET_SFTP_INIT',
             2  => 'NET_SFTP_VERSION',


### PR DESCRIPTION
After modifying the SSH2 constructor, SFTP constructor should extend it.
