### PR TITLE
make library work on php 5.3.3

### DIFF
--- a/lib/Sinner/Phpseclib/Crypt/AES.php
+++ b/lib/Sinner/Phpseclib/Crypt/AES.php
@@ -244,7 +244,7 @@ class Crypt_AES extends Crypt_Rijndael {
         }
 
         if (CRYPT_AES_MODE == CRYPT_AES_MODE_INTERNAL) {
-            parent::Crypt_Rijndael($this->mode);
+            parent::__construct($this->mode);
         }
     }
 


### PR DESCRIPTION
Hi There

As of PHP 5.3.3, methods with the same name as the last element of a namespaced class name will no longer be treated as constructor. This change doesn't affect non-namespaced classes.

Cheers