### PR TITLE
Update SFTP.php

### DIFF
--- a/lib/Sinner/Phpseclib/Net/SFTP.php
+++ b/lib/Sinner/Phpseclib/Net/SFTP.php
@@ -548,7 +548,7 @@ class Net_SFTP extends Net_SSH2 {
             $dir = $dir[0] == '/' ? '/' . rtrim(substr($dir, 1), '/') : rtrim($dir, '/');
 
             if ($dir == '.' || $dir == $this->pwd) {
-                return $this->pwd . $file;
+                return $this->pwd . '/' . $file;
             }
 
             if ($dir[0] != '/') {


### PR DESCRIPTION
_realpath function generates invalid path, no separator between dir and file.
It would be a good idea to upgrade to the latest version of the phpseclib library
