### PR TITLE
phpseclib 0.3.6, SSH2 class, line 2400 change.

### DIFF
--- a/lib/Sinner/Phpseclib/Net/SSH2.php
+++ b/lib/Sinner/Phpseclib/Net/SSH2.php
@@ -1936,7 +1936,7 @@ class Net_SSH2 {
         while (true) {
             if ($mode == NET_SSH2_READ_REGEX) {
                 preg_match($expect, $this->interactiveBuffer, $matches);
-                $match = $matches[0];
+                $match = isset($matches[0]) ? $matches[0] : '';
             }
             $pos = !empty($match) ? strpos($this->interactiveBuffer, $match) : false;
             if ($pos !== false) {


### PR DESCRIPTION
read method threw an exception when nothing matches $expect