### PR TITLE
Update SFTP.php

### DIFF
--- a/lib/Sinner/Phpseclib/Net/SFTP.php
+++ b/lib/Sinner/Phpseclib/Net/SFTP.php
@@ -1542,6 +1542,7 @@ class Net_SFTP extends Net_SSH2 {
         $this->_logError($response);
 
         // check the status from the NET_SFTP_STATUS case in the above switch after the file has been closed
+        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             return false;
         }


### PR DESCRIPTION
Hello,

I encountered a PHP Notice, while trying to get a file content from SFTP class:
PHP Notice: Undefined variable: status in vendor/sinner/phpseclib-bundle/lib/Sinner/Phpseclib/Net/SFTP.php on line 1545.

Maybe is it because of the missing line "extract(unpack('Nstatus', $this->_string_shift($response, 4)));" (that appears in every other function like put() or mkdir()) in get function?

Would you consider fixing it, please?

Thanks
